### PR TITLE
Stop serializing logwarning over pytest

### DIFF
--- a/pytest_idapro/plugin_worker.py
+++ b/pytest_idapro/plugin_worker.py
@@ -58,10 +58,6 @@ class WorkerPlugin(BasePlugin):
     def pytest_internalerror(self, excrepr, excinfo):
         self.worker.send('internalerr', excrepr, excinfo)
 
-    # unsupported
-    def pytest_logwarning(self, message, code, nodeid, fslocation):
-        self.worker.send('logwarning', message, code, nodeid, fslocation)
-
     def pytest_sessionstart(self, session):
         self.worker.send('session', 'start')
 


### PR DESCRIPTION
Because of a bug in pytest-cov, a warning may be thrown when its used.
Because we dont currently handle those warnings in the external side, execution abruptly terminates.