### PR TITLE
Support python3 replay

### DIFF
--- a/pytest_idapro/__init__.py
+++ b/pytest_idapro/__init__.py
@@ -1,3 +1,3 @@
 from . import plugin
 
-__version__ = '0.4.1'
+__version__ = '0.4.2'


### PR DESCRIPTION
1. sort instances by key to avoid dict comparison.
2. replace deprecated warn with warning
3. avoid raisning ValueError instead of AttributeError to properly handle hasattr.
   this wasn't an issue with python2 because it's hasattr silences most exceptions